### PR TITLE
Add username to additional information

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 
   </script>
   <script type="text/javascript" src="https://cdn.jsdelivr.net/sweetalert2/6.4.4/sweetalert2.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/axios/dist/axios.min.js"></script>
   <script type="text/javascript" src="js/infinite-scroll.js"></script>
   <script type="text/javascript" src="http://cdn.mubaris.com/js/emoji.js"></script>
   <script type="text/javascript" src="js/usernames.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -49,7 +49,7 @@ if (window.localStorage) {
     if (!localStorage.getItem("accessToken")) {
         swal({
             title: "Submit Github Token",
-            html: "Curiosity uses Github Token to access Github API. Your token will be saved in LocalStorage. So don't worry. Get new token <a target='_blank' href='https://github.com/settings/tokens/new'>here</a>.",
+            html: "Curiosity requires a Github Token to access Github API. Your token will be saved in LocalStorage. So don't worry. Get new token <a target='_blank' href='https://github.com/settings/tokens/new?description=Curiosity'>here</a>.",
             input: "text",
             showCancelButton: true,
             confirmButtonText: "Submit",

--- a/js/main.js
+++ b/js/main.js
@@ -2,37 +2,6 @@ var emoji = new EmojiConvertor();
 var reqNo = Math.floor(Math.random() * 3) + 1;
 var perPage = 2;
 
-function httpGetAsync(url) {
-    return new Promise(function(resolve, reject) {
-      var xmlHttp = new XMLHttpRequest();
-      xmlHttp.onreadystatechange = function() {
-          if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
-              resolve(xmlHttp.responseText);
-      };
-      xmlHttp.open("GET", url, true);
-      xmlHttp.send(null);
-      reqNo += 1;
-      setTimeout(function() {
-          reject("API Request failed to resolve.");
-      }, 10000);
-    });
-}
-
-function getData(token) {
-    for (i = 0; i < usernames.length; i++) {
-        const username = usernames[i];
-        url = "https://api.github.com/users/" + username + "/starred?per_page=" + perPage + "&access_token=" + token + "&page=" + reqNo + 1;
-        httpGetAsync(url)
-            .then(response => {
-                dataCollector(response, username);
-            })
-            .catch(err => {
-                // Ignore the failed API request.
-                // If the request does happen to resolve at some point after the timeout it will still be processed.
-            });
-    }
-}
-
 function nFormatter(num) {
     if (num <= 999) {
         return num + "";
@@ -45,12 +14,9 @@ function userFormatter(username) {
   return "<a href='https://github.com/" + username + "?tab=stars'>" + username + "</a>";
 }
 
-var content = document.getElementById("content");
-var dataStorage = [];
-
 function dataCollector(response, username) {
     //dataStorage.push(response);
-    JSON.parse(response).forEach(function(entry) {
+    response.data.forEach(function(entry) {
         if (typeof entry != "undefined") {
             var innerContent = "<li><span class='link'><a href='" + entry.html_url + "' target='_blank'>" + entry.name + "<span> - " + String(entry.description) + "</span>" + "<br/></a></span>";
             innerContent += "<div class='additional'>";
@@ -65,6 +31,26 @@ function dataCollector(response, username) {
         }
     });
 }
+
+function getData(token) {
+    for (var i = 0; i < usernames.length; i++) {
+        const username = usernames[i];
+        var url = "https://api.github.com/users/" + username + "/starred?per_page=" + perPage + "&access_token=" + token + "&page=" + reqNo + 1;
+
+        axios({
+            url,
+            method: "get",
+            responseType: "json"
+        }).then((response) => {
+            dataCollector(response, username);
+        }).catch((err) => {
+            // Do nothing.
+        });
+    }
+}
+
+var content = document.getElementById("content");
+var dataStorage = [];
 
 if (window.localStorage) {
     if (!localStorage.getItem("accessToken")) {


### PR DESCRIPTION
* Add a default description to the Github API token generation page.
* Switch `httpGetAsync` to return a promise. It might be worthwhile to look at an async library for this if you end up needing more api calls.
  * This isn't the right way to reject an http request. It should probably be updated to check for rejection status codes and `reject` on that.

Might consider mentioning that the API token doesn't require any additional permissions.

Closes #7 