### PR TITLE
Removed redundant 'Error' from invalid error

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -106,7 +106,7 @@ if (window.localStorage) {
                             }).then(() => {
                                 localStorage.setItem('accessToken', token);
                                 resolve();
-                            }).catch(() => reject(new Error('Error: invalid token')));
+                            }).catch(() => reject(new Error('Invalid token')));
                         }
                     }, 1000);
                 });


### PR DESCRIPTION
Error() adds "Error: " so you don't need it in the string as well. In the app the error reads "Error: Error: invalid token." Also capitalized invalid to keep consistent with other error messages.